### PR TITLE
Expand API of `Pca` and `RandomizedPca`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
     - name: Build
       run: cargo build --verbose --features "serialization"
     - name: Run tests
-      run: cargo test --verbose --features "serialization"
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      run: |
+        export LD_LIBRARY_PATH=`ls -d target/debug/build/intel-mkl-src-*/out`
+        cargo test --verbose --features "serialization"
     - name: Generate coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Pca::components()` and `RandomizedPca::components()`.
+- `Pca::mean()` and `RandomizedPca::mean()`.
+- `Pca::inverse_transform()` and `RandomizedPca::inverse_transform()`.
+
 ## [0.4.0] - 2020-06-18
 
 ### Added
@@ -50,6 +58,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Principal component analysis (PCA).
 
+[Unreleased]: https://github.com/petabi/petal-decomposition/compare/0.4.0...master
 [0.4.0]: https://github.com/petabi/petal-decomposition/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/petabi/petal-decomposition/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/petabi/petal-decomposition/compare/0.1.1...0.2.0


### PR DESCRIPTION
Added the followings:

- `Pca::components()` and `RandomizedPca::components()`.
- `Pca::mean()` and `RandomizedPca::mean()`.
- `Pca::inverse_transform()` and `RandomizedPca::inverse_transform()`.
