### PR TITLE
chore: upgrade ndarray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ serialization = [
 
 [dependencies]
 itertools = "0.13"
-lair = "0.6"
+lair = "0.7"
 lapack = "0.19"
-ndarray = "0.15.2"
+ndarray = "0.16.1"
 num-complex = "0.4"
 num-traits = "0.2.15"
 rand = "0.8"
@@ -78,7 +78,7 @@ optional = true
 
 [dev-dependencies]
 approx = "0.5"
-ndarray = { version = "0.15", features = ["approx"] }
+ndarray = { version = "0.16", features = ["approx"] }
 serde_json = "1"
 
 [packages.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ exclude = ["./github"]
 [badges]
 codecov = { repository = "petabi/petal-decomposition", service = "github" }
 
+[lints.clippy]
+pedantic = "warn"
+
 [package.metadata.docs.rs]
 no-default-features = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(any(feature = "intel-mkl-static", feature = "intel-mkl-system"))]
 extern crate intel_mkl_src as _src;
 
-#[cfg(any(feature = "netlib_static", feature = "netlib-system"))]
+#[cfg(any(feature = "netlib-static", feature = "netlib-system"))]
 extern crate netlib_src as _src;
 
 #[cfg(any(feature = "openblas-static", feature = "openblas-system"))]

--- a/src/linalg/lapack.rs
+++ b/src/linalg/lapack.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::cast_sign_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#![allow(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 
 use lair::Scalar;
 use num_complex::{Complex32, Complex64};

--- a/src/linalg/lapack.rs
+++ b/src/linalg/lapack.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::cast_sign_loss, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
 use lair::Scalar;
 use num_complex::{Complex32, Complex64};
 use num_traits::{ToPrimitive, Zero};


### PR DESCRIPTION
Upgrade ndarray and transitive dependencies.
- Updated dependency versions
- Add clippy pedantic lint to Cargo.toml to align with CI check
- Allow LAPACK pedantic clippy lints which are failing
- Fix feature flag naming for consistency